### PR TITLE
Serverless can now be started with a custom port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 .vscode/**
 /**/*.tar
 /**/*.zip
+.idea/**

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # cvs-svc-stub-crm-atfs
+
+#### Run AWS Lambda node functions locally with a mock API Gateway
+- `npm install`
+- `npm start` to start serverless locally with default ports
+-  `SERVERLESS_PORT={serverless port} ./node_modules/serverless/bin/serverless offline start` to start serverless locally with custom ports
+
+### Git Hooks
+
+Please set up the following prepush git hook in .git/hooks/pre-push
+
+```
+#!/bin/sh
+npm run prepush && git log -p | scanrepo
+
+```
+
+#### Security
+
+Please install and run the following securiy programs as part of your testing process:
+
+https://github.com/awslabs/git-secrets
+
+- After installing, do a one-time set up with `git secrets --register-aws`. Run with `git secrets --scan`.
+
+https://github.com/UKHomeOffice/repo-security-scanner
+
+- After installing, run with `git log -p | scanrepo`.
+
+These will be run as part of prepush so please make sure you set up the git hook above so you don't accidentally introduce any new security vulnerabilities.
+
+### Testing
+In order to test, you need to run the following:
+- `npm run test` for unit tests
+- `npm run test-i` for integration tests
+- `npm run tests` to run both
+
+
+### Environmental variables
+
+- The `SERVERLESS_PORT` environment variable needs to be set to a value representing the port you want the serverless instance to run on. This variable is mandatory. Defaults to `3000`

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "CRM-stub service that stores and serves the ATF data",
   "main": "handler.js",
   "scripts": {
-    "start": "npm run eslint && serverless offline start",
+    "start": "npm run eslint && SERVERLESS_PORT=${SERVERLESS_PORT:-3000} ./node_modules/serverless/bin/serverless offline start",
     "test": "node_modules/.bin/mocha tests/**/*.unitTest.js",
-    "test-i": "node_modules/.bin/mocha tests/**/*.intTest.js",
-    "tests": "npm run test && sls offline start > /dev/null 2>&1 & sleep 4 && npm run test-i && kill %1",
+    "test-i": "npm run start > /dev/null 2>&1 & sleep 5 && SERVERLESS_PORT=${SERVERLESS_PORT:-3000} node_modules/.bin/mocha tests/**/*.intTest.js && pkill -2 node",
+    "tests": "npm run test && npm run test-i",
     "prepush": "npm test && npm run eslint",
     "predeploy": "npm install && npm run prepush",
     "security-checks": "git secrets --scan && git log -p | scanrepo",

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: 
+service:
   name: cvs-svc-stum-crm-atfs
 
 openapi: 3.0.0
@@ -12,40 +12,42 @@ provider:
   runtime: nodejs8.10
 
 custom:
+  serverless-offline:
+    port: ${env:SERVERLESS_PORT}
   documentation:
     version: '1'
     title: 'Get ATF List API'
     description: 'This is the API spec for retrieving all existing ATFs'
-    models: 
+    models:
       - name: "ATFs"
         description: "Get ATFs successful response"
         contentType: "application/json"
-        schema: 
+        schema:
           type: "array"
-          items: 
+          items:
             type: "object"
-            properties: 
+            properties:
               atfId:
                 type: "string"
               atfNumber:
                 type: "string"
-              atfName: 
+              atfName:
                 type: string
               atfContactNumber:
-                type: string 
-              atfAccessNotes: 
                 type: string
-              atfGeneralNotes:  
+              atfAccessNotes:
                 type: string
-              atfTown: 
+              atfGeneralNotes:
                 type: string
-              atfAddress: 
+              atfTown:
                 type: string
-              atfPostcode: 
+              atfAddress:
                 type: string
-              atfLongitude: 
+              atfPostcode:
+                type: string
+              atfLongitude:
                 type: number
-              atfLatitude: 
+              atfLatitude:
                 type: number
 
 functions:
@@ -62,7 +64,7 @@ functions:
               - statusCode: 200
                 responseBody:
                   description: "List of ATFs"
-                responseModels: 
+                responseModels:
                   "application/json": "ATFs"
               - statusCode: 500
                 responseBody:

--- a/tests/integration/atf.intTest.js
+++ b/tests/integration/atf.intTest.js
@@ -2,7 +2,7 @@
 const supertest = require('supertest')
 const expect = require('expect')
 
-const url = 'http://localhost:3000/atf'
+const url = `http://localhost:${process.env.SERVERLESS_PORT}/`
 const request = supertest(url)
 
 describe('atfs', () => {
@@ -10,7 +10,7 @@ describe('atfs', () => {
     context('all atfs', () => {
       it('should return all atfs', (done) => {
         request
-          .get('/')
+          .get('atf')
           .set('Context-Type', 'application/json')
           .set('authorization', 'allow')
           .expect(200)


### PR DESCRIPTION
## Changes
* Added readme.
* Added the functionality to start serverless with custom port by specifying the environment variable SERVERLESS_PORT=[PORT].
* Changed test scripts.